### PR TITLE
Added a proper .travis.ml that builds all.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,35 @@
 language: java
-jdk: 
-    - openjdk6
+os:
+  - linux
+  - osx
+# Install packages using apt-get on linux environment
+addons:
+  apt:
+    sources:
+    - avsm
+    packages:
+    - opam
+before_install:
+  # Install packages using brew on osx environment
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install opam ant; fi
+  - opam init --auto-setup
+  - eval `opam config env`
+  - opam install --yes ocamlfind menhir fileutils
 install:
-    - cd touist-gui
-    - ant build
-    - ant build-jar
+  - cd touist-translator
+  - ./configure --bindir ../touist-gui/external
+  - make && make install
+  - cd ../touist-gui
+  - chmod ugo+x external/touistc  
+  - ant zip
+  - zip=$(ls | grep 'touist.*\.zip' | head -1)
 script:
-    - echo "Build succeded... Now, run `ant dist` or `ant zip`"
+  - echo "Build succeded. No tests yet."
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: VRD3mGBKw4BJ/4IPqKGg9c5Iscxz3cDAG2W7cj78FiTYlEtSZT3P0WZVJZdrGFI4aIq9KaHbHjpmtqRR3B30Nv/dFecaTwhnDbn4No/K/YYmOGwe0jiEQcYst/uSThWg1cNk0ml4mbfCZGgZNIdHnF77lchbfmsm3e85vNc43+UsIMTxc3OHkFe6L4sRsf4yjcdNwQgIQzEGsy1A5EkEnVkbLXxAbRI3Q49R0vTGWf8WlECiU8tBX8CyMKb5kny5ZJQG35KxGG3TSRhAqXl43yRbUlmc/21T3Wz69ceBx/gqF6Di88mnLJAzOtr9EhEp4eCGt4Q+d4Q66NWlZsivRK+FnYKnLKxHbb1esxwlz+PqYIUIT4HQfzfzZ5EBWNvbh9DmPSPG1LC2zbDAQFErufjbe+acrNNGNcw3zRlSsWetqtIobGNupdw/tudrkBFXhQc5IovnhNQKmZztDAaDfX9WC8aseXDrjZqq+4Wt03WgbEspscwow8xGP8BYjZe5co1Titu8S3vI6O84exLZoukQ1owFcLACrppFwsYRSPAe3cFdM4LjYbw/579gk2iOCasamiGSk56Wzc5Ik9emDEa2lEVYUGdcQ+dUGhnbzg8jpN1YPqSzxCz0TLf8gACoBYxWFSgg2rSEQmkDVFLpfo4tQGSh3W3vB6MxBxOrXb0=
+  file: $zip
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-TouIST Project
-==============
-![Formulas](https://cloud.githubusercontent.com/assets/2195781/7631376/8b0a1e66-fa41-11e4-9d14-5fd39da7c494.png)
+TouIST, the IDE for propositional logic
+=======================================
+
+![The Travis build state: says if the java project can be built of not](https://travis-ci.org/FredMaris/touist.svg?branch=master)
 
 TouIST is a user-friendly tool for solving propositionnal logic problems using a high-level logic language (known as the _bigand_ format or syntax or language). This language allows complex expressions like _big and_, _sets_... 
 
@@ -8,24 +9,36 @@ We can for example solve the problem "Wolf, Sheep, Cabbage", or a sudoku, or any
 
 The TouIST has been initialized by Frederic Maris and Olivier Gasquet, associate professors at the _Institut de Recherche en Informatique de Toulouse_ (IRIT). It is a "second" or "new" version of a previous program, [SAToulouse](http://www.irit.fr/satoulouse/).
 
-The development is done by a team of five students in first year of master's degree at the _Université Toulouse III — Paul Sabatier_. This project is a part of their work at school.
+The development is done by a team of five students in first year of master's degree at the _Université Toulouse III — Paul Sabatier_. This project is a part of their work at school. See [CONTRIBUTORS](https://github.com/FredMaris/touist/blob/master/CONTRIBUTORS.md).
 
-## Download it
-[Get the last release](https://github.com/olzd/touist/releases). For now, Touist is compatible with:
+![Formulas](https://cloud.githubusercontent.com/assets/2195781/7631376/8b0a1e66-fa41-11e4-9d14-5fd39da7c494.png)
+
+## Download it  
+[Get the latest release](https://github.com/FredMaris/touist/releases). For now, Touist is compatible with:
 
 - Mac OS X Intel 64 bits
 - Linux 64 bits
 
 Touist is platform-specific because of the ocaml `touist` translator that translates the high-level `.touistl` (touist language files) into `SAT_DIMACS` or `SMT2` is compiled into an architecture-specific binary (for performances).
 
-We have some issues with compiling the ocaml translator for Windows. Some of the first releases have been compiled for Windows, but the tool we used has been discontinued ([see corresponding issue](https://github.com/olzd/touist/issues/5)).
+We have some issues with compiling the ocaml translator for Windows. Some of the first releases have been compiled for Windows, but the tool we used has been discontinued ([see corresponding issue](https://github.com/FredMaris/touist/issues/5)).
 
-## How does Touist work?
-![archi](https://cloud.githubusercontent.com/assets/2195781/7631517/94c276e0-fa43-11e4-9a5c-351b84c2d1e1.png)
 
-- **GUI interface**: the Java/Swing window that opens where you click on `touist.jar`. When you click on `Test`, the GUI will ask the Translator to translate the touistl file. Then, the GUI asks the Solver to compute the models.
-- **Translator**: the program `external/touistc` that translates a `.touistl` file into a `.sat/.smt` file. This program, developed during this project, can be also used in command line. `./external/touistc --help` will show you what you can do.
-- **Solver SAT/SMT**: it takes the `.sat`/`.smt` file and computes the models. We just embed existing binaries/libraries.
+## What is Touist made of?
+Touist uses Java (>= jre6) and embeds an architecture-specific binary, [touistc](https://github.com/FredMaris/touist/tree/master/touist-translator) (we coded it in ocaml), which translates touistl language to dimacs. The dimacs files are then given to another binary, the SAT (or SMT) solver, and then displayed to the user.
 
-## What exists besides Touist
-SAToulouse had several drawbacks and had to be re-written. If you want to have a look at what SAToulouse looks like, see http://www.irit.fr/satoulouse/.
+_touistc_ can also be used in command-line.
+
+
+## Rebuilding-it
+See the [./INSTALL.md](https://github.com/FredMaris/touist/blob/master/INSTALL.md) file.
+
+------------
+Here is a small figure showing the architecture of the whole program:   
+![Architecture of touist](https://cloud.githubusercontent.com/assets/2195781/7631517/94c276e0-fa43-11e4-9a5c-351b84c2d1e1.png)
+
+## Bugs and feature requests
+You can report bugs by creating a new Github issue. Feature requests can also be submitted using the issue system.  
+
+You can contribute to the project by forking/pull-requesting.
+

--- a/touist-gui/README.md
+++ b/touist-gui/README.md
@@ -1,14 +1,12 @@
 TouIST main program
 ===================
-![The Travis build state: says if the java project can be built of not](
-https://travis-ci.org/FredMaris/touist.svg?branch=master)
 
 This folder contains the source code for the main program of the TouIST 
 project. It is named GUI because of it's main feature: be the user 
-interface for the SAT/SMT solver and `touistc` translator.
+interface for the SAT/SMT solver and `touistc` translator. The whole GUI is written in Java/SWING.
 
 
-## Conception & architecture of the project
+## Java Architecture
 ![conception](https://www.lucidchart.com/publicSegments/view/54f46f57-1ff4-46e0-b146-65000a009e9c/image.png)
 
 ## How to change the external solver used

--- a/touist-gui/build.xml
+++ b/touist-gui/build.xml
@@ -54,17 +54,6 @@
 
 
 	<!-- 
-		 Commands executed before any target is executed
-
-		 Here we chose to remove the `./touist-gui/dist` 
-		 directory to be sure the new builds will produce 
-		 a clean dist (= program distributed for users)
-	-->
-	<delete dir="${touist.dist.dir}"/>
-
-
-
-	<!-- 
 		`ant build`
 
 		Builds all the .java files in `src`
@@ -142,13 +131,14 @@
 		It basically creates the directory and copies the `touist.jar` and
 		`external/` into it.
 	-->
-	<target depends="build-jar" name="dist">
+	<target name="dist" depends="build-jar">
 		<!-- Copy the external binaries into dist/ -->
 		<copy file="${touist.dir}/touist.jar" todir="${touist.dist.dir}"/>
 		<copy todir="${touist.dist.dir}/external" flatten="true">
-			<fileset dir="${touist.external.dir}"/>
+			<fileset dir="${touist.external.dir}">
+				<exclude name="**/*.zip"/><!--Ignore the yices-smt2.zip--> 
+			</fileset>
 		</copy>
-		<chmod dir="${touist.dist.dir}/external" perm="ugo+rx" includes="*"/>
 	</target>
 
 
@@ -158,8 +148,11 @@
 
 		After calling `build`, `build-jar` and `dist`, this target
 		basically renames the `dist` folder to something like 
-			"touist-v1.1-Mac_OS_X-x86_64"
+			   "touist-v1.1-Mac_OS_X-x86_64"
+			or "touist-v1.1-17-g8e47c99-Linux-amd64"
 		and then zips this folder.
+		
+		NOTE: g8e47c99 means that it is the git revision 8e47c99
 
 		This result of this target will be distributed to end-users.
 	-->
@@ -178,15 +171,30 @@
 				</tokenfilter>
 			</filterchain>
 		</loadfile>
-		<delete dir="some.tmp.file"/>
-		<rename src="${touist.dist.dir}" 
-			dest="${touist.dist.zip.name.filtered}"/>
-		<zip destfile="${touist.dist.zip.name.filtered}.zip" 
-			basedir="${touist.dist.zip.name.filtered}" />
+		<delete file="some.tmp.file"/>
+		<zip destfile="${touist.dist.dir}.zip" basedir="${touist.dist.dir}">
+			<!-- Binaries in zip loose their permissions. Set them to 755 -->
+			<zipfileset filemode="755" dir="${touist.dist.dir}" 
+				includes="external/*"/>
+		</zip>
+		<copy file="${touist.dist.dir}.zip" 
+			toFile="${touist.dist.zip.name.filtered}.zip"/>
 	</target>
 
+
+	<!--
+		 `ant clean`
+		 
+		 Cleans the touist-gui directory from build/dist files.
+	-->
 	<target name="clean">
-		<delete dir="${touist.build.dir}"/>
+		<delete includeEmptyDirs="true" failonerror="false">
+			<fileset dir="${touist.build.dir}"/>
+			<fileset dir="${touist.dist.dir}"/>
+			<fileset dir="${touist.dir}" includes="**/touist*.zip"/>
+			<fileset dir="${touist.dir}" includes="**/dist*.zip"/>		
+			<fileset dir="${touist.dir}" includes="**/touist.jar"/>						
+		</delete>
 	</target>
 
 
@@ -236,6 +244,12 @@
 			<entry key="build.date" value="${build.date}"/>
 			<entry key="minimum_java_version" value="${target}"/>
 		</propertyfile>
+		<!-- Prevent git from saying the repo is dirty -->
+		<exec executable="git" failifexecutionfails="false"> 
+             <arg value="update-index"/>
+             <arg value="--assume-unchanged"/>
+             <arg value="${touist.resources.dir}/version.properties"/>
+        </exec>
 	</target>
 
 
@@ -337,3 +351,5 @@
 	</target> 
 
 </project>
+
+


### PR DESCRIPTION
Travis now builds both touist-translator and touist-gui.
I also modified the touist-gui/build.xml to fit the
.travis.ml file.

On each tag, both osx and linux releases are going to be pushed to the
Github releases.

I also modified the README.md and INSTALL.md to be more compelling and
easier to understand.