### PR TITLE
atmost ne fonctionne pas, la table de correspondance est fausse

### DIFF
--- a/touist-translator/src/eval.ml
+++ b/touist-translator/src/eval.ml
@@ -485,10 +485,10 @@ and exact_str lst =
 and atleast_str lst =
   List.fold_left (fun acc str -> COr (acc, clause_of_string_list str)) Bottom lst
 
-and atmost_str =
+and atmost_str lst =
   List.fold_left (fun acc str ->
     COr (acc, List.fold_left (fun acc' str' ->
-      CAnd (acc', CNot (Term (str',None)))) Top str)) Bottom
+      CAnd (acc', CNot (Term (str',None)))) Top str)) Bottom lst
 
 and clause_of_string_list =
   List.fold_left (fun acc str -> CAnd (acc, Term (str,None))) Top

--- a/touist-translator/src/eval.ml
+++ b/touist-translator/src/eval.ml
@@ -488,7 +488,7 @@ and atleast_str lst =
 and atmost_str =
   List.fold_left (fun acc str ->
     COr (acc, List.fold_left (fun acc' str' ->
-      CAnd (acc, CNot (Term (str',None)))) Top str)) Bottom
+      CAnd (acc', CNot (Term (str',None)))) Top str)) Bottom
 
 and clause_of_string_list =
   List.fold_left (fun acc str -> CAnd (acc, Term (str,None))) Top


### PR DESCRIPTION
Suite à l'issue #115, j'ai tenté de découvrir pourquoi la table de correspondance (cf. l'issue) n'était pas correcte. J'ai perdu pas mal de temps à comprendre comment le code fonctionnait...

Au final, un peu au hasard, j'ai remarqué qu'il semblait manquer un `'` dans `atmost_str`. 

Mais vu que je ne maitrise pas du tout le code, je suis pas sûr de moi... @olzd, si tu as deux secondes, pourrais-tu jeter un coup d'oeil à ma modif ? Merci :sweat_smile: 

Fixes #115 

------------ 
Après avoir rajouté `'`, voilà ce que j'obtiens : 

```shell
echo "begin formula atmost(1,[a,b,c]) end formula" | ./external/touistc -sat /dev/stdin -o /dev/stdout -table /dev/stdout
```
Le résultat en CNF : 
```
c CNF format file
p cnf 7 8
5 2 0
-5 7 4 0
-5 -7 -6 0
-5 -7 -3 0
-5 -4 -6 0
-5 -4 -1 0
-2 -3 0
-2 -1 0
```
Et la table de correspondance : 
```
a 6
&4 5
&3 2
b 3
&6 7
&5 4
c 1
```
Cette fois on a bien a, b et c.