### PR TITLE
La taille des boutons dans la fenêtre des sets trop grande

### DIFF
--- a/touist-gui/src/gui/editionView/PalettePanel.java
+++ b/touist-gui/src/gui/editionView/PalettePanel.java
@@ -133,11 +133,11 @@ public class PalettePanel extends AbstractComponentPanel {
     }
     
     public int getRecommendWidth() {
-        int width = 160;
+        int width = 0;
         for (Component section : sectionsContainerPanel.getComponents()) {
             if (section instanceof PaletteSectionPanel) {
                 for (InsertionButton button : ((PaletteSectionPanel)section).getButtons()) {
-                    width = (int) Math.max(width, button.getIcon().getIconWidth() * 2.5);
+                    width = 8+(int) Math.max(width, button.getIcon().getIconWidth());
                 }
             }
         }


### PR DESCRIPTION
I removed the 160 minimum size because it seemed useless.
Instead of multiplicating the size of the button by 2.5, I
decided to add up 8 pixels, which actually makes the rendering
much better.

Before/after  
![capture d ecran 2016-03-18 a 10 33 32](https://cloud.githubusercontent.com/assets/2195781/13873927/f7d920f4-ecf4-11e5-9099-de9aac26761e.png)![capture d ecran 2016-03-18 a 10 33 07](https://cloud.githubusercontent.com/assets/2195781/13873922/ee657a7c-ecf4-11e5-8e0e-247404d03624.png)

![capture d ecran 2016-03-18 a 10 33 40](https://cloud.githubusercontent.com/assets/2195781/13873925/f541fd0c-ecf4-11e5-8fcf-4661d5e29b69.png)![capture d ecran 2016-03-18 a 10 33 14](https://cloud.githubusercontent.com/assets/2195781/13873921/eb88372c-ecf4-11e5-987a-c4bc7845c014.png)

