### PR TITLE
More explicit message when touistc is missing (or other external binaries)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ v1.1.2 (future)
   - touistc: In SMT mode, "Float" was produced instead of "Real" (Frédéric Maris)
   - touistc: Now display a proper error when -smt2 is given with no logic	(Maël Valais)
   - gui: the left "snippets" panel has now a correct size (Maël Valais)
+  - gui: more explicit error message when touistc is missing (Maël Valais)
 
 v1.1.1
   - gui: dollars in variables are now displaying in bold font in latex (Maël Valais)

--- a/touist-gui/src/gui/editionView/ParentEditionPanel.java
+++ b/touist-gui/src/gui/editionView/ParentEditionPanel.java
@@ -524,7 +524,7 @@ public class ParentEditionPanel extends AbstractComponentPanel {
                 f.deleteOnExit();
             } catch (IOException ex) {
                 ex.printStackTrace();
-                errorMessage = "The translator returned an IOException: \n"+ex.getMessage();
+                errorMessage = "The translator returned an IOException: \n"+ex.getMessage()+"\nCheck that touistc is in external/ and that it has the right permissions.";
                 showErrorMessage(ex, errorMessage, getFrame().getLang().getWord(Lang.ERROR_TRADUCTION));
                 return State.EDITION;
             } catch (InterruptedException ex) {


### PR DESCRIPTION
Or that touistc doesn't have the right permissions under unix systems.

<!---
@huboard:{"order":42.375,"milestone_order":138,"custom_state":""}
-->
